### PR TITLE
도서 정보 삭제/수정 이미지 처리 

### DIFF
--- a/Panel_Edit.py
+++ b/Panel_Edit.py
@@ -162,13 +162,12 @@ class Panel_Edit_Book():
         def open_dialog():
             filename = askopenfilename(parent=window,filetypes=(("이미지 파일", IMG_FILE_TYPE),("모든 파일","*.*")))
             # 원본 이미지 데이터 반환
-            
+
             # 이미지 저장 중 취소 버튼 선택시 오류 발생 수정
             try:
                 self.image = Image.open(filename)
             except:
                 return 0
-
             resize_image = self.image.resize((IMG_WIDTH, IMG_HEIGHT))
             image_tk = ImageTk.PhotoImage(resize_image,master=window)
             self.label_image.configure(image=image_tk, width=IMG_WIDTH, height=IMG_HEIGHT)

--- a/Panel_Show.py
+++ b/Panel_Show.py
@@ -565,7 +565,7 @@ class Panel_Show_Book():
         if self.isbn == int(ISBN):
             # (덮어쓰기)
             try:
-                self.book_editor.image.save(book_image_address, "gif")
+                self.book_editor.image.save(book_image_address, "png")
                 image = Image.open(book_image_address)    
                 resize_image = image.resize((IMG_WIDTH, IMG_HEIGHT))
                 self.image_tk = ImageTk.PhotoImage(resize_image)
@@ -575,7 +575,7 @@ class Panel_Show_Book():
             except:
                 # 파일 ISBN, 사진 그대로 저장
                 image = Image.open(self.image_address)
-                image.save(book_image_address, "gif") # (덮어쓰기)
+                image.save(book_image_address, "png") # (덮어쓰기)
                 reisze_image = image.resize((IMG_WIDTH, IMG_HEIGHT))
                 self.image_tk = ImageTk.PhotoImage(reisze_image)
                 self.book_editor.label_image.configure(image=self.image_tk, width=IMG_WIDTH, height=IMG_HEIGHT)
@@ -583,7 +583,7 @@ class Panel_Show_Book():
         else:
             try:
                 # ISBN, 파일 모두 변경
-                self.book_editor.image.save(book_image_address, "gif")
+                self.book_editor.image.save(book_image_address, "png")
                 image = Image.open(book_image_address)
                 # 만약 ISBN이 이전과 다르면 새로운 이름을 가진 파일이 추가되었을거임.
                 resize_image = image.resize((IMG_WIDTH, IMG_HEIGHT))
@@ -594,7 +594,7 @@ class Panel_Show_Book():
                 remove(self.image_address)
             except:
                 image = Image.open(self.image_address)     
-                image.save(book_image_address, "gif")
+                image.save(book_image_address, "png")
                 image = Image.open(book_image_address)
                 reisze_image = image.resize((IMG_WIDTH, IMG_HEIGHT))
                 self.image_tk = ImageTk.PhotoImage(reisze_image)

--- a/Panel_Show.py
+++ b/Panel_Show.py
@@ -403,6 +403,7 @@ class Panel_Show_Book():
             if self.Search.cancel == True:
                 return None
 
+            # self.isbn = int 타입
             self.isbn = self.Search.getTable[0]
             df_book = pd.read_csv(DIR_CSV_BOOK, encoding='CP949')
             df_book.set_index(df_book["BOOK_ISBN"], inplace=True)
@@ -418,15 +419,12 @@ class Panel_Show_Book():
 
             # 도서 정보 검색
             self.title = df_book.loc[self.isbn, "BOOK_TITLE"]
-
-
             self.author = df_book.loc[self.isbn, "BOOK_AUTHOR"]
             self.publisher = df_book.loc[self.isbn, "BOOK_PUB"]
             self.price = df_book.loc[self.isbn, "BOOK_PRICE"]
-            self.book_explain = df_book.loc[self.isbn, "BOOK_DESCRIPTION"]
             self.image_address = df_book.loc[self.isbn, "BOOK_IMAGE"]
             self.link = df_book.loc[self.isbn, "BOOK_LINK"]
-
+            self.book_explain = df_book.loc[self.isbn, "BOOK_DESCRIPTION"]
 
             # 도서 이미지 찾기, 조절
             image = Image.open(self.image_address)
@@ -444,7 +442,7 @@ class Panel_Show_Book():
             self.book_editor.label_image.configure(image=self.image_tk, width=IMG_WIDTH, height=IMG_HEIGHT)
             self.book_editor.label_image.image = self.image_tk
             self.update_table()
-        except EOFError:
+        except:
             pass
 
     # 멤버 메소드: 도서 정보 [삭제] 버튼 이벤트
@@ -457,36 +455,23 @@ class Panel_Show_Book():
         df_rent = pd.read_csv(DIR_CSV_RENT, encoding='CP949', index_col=0)
         df_rent.index.name = "RENT_SEQ"     # Auto Increment를 인덱스로 하며, 별칭 설정
 
-# <<<<<<< HEAD
-        try:
-            if self.isbn in list(df_rent["BOOK_ISBN"]):
-                messagebox.showinfo("도서 정보 삭제 불가", "{}({})는(은) 이미 대출 중이라 삭제할 수 없습니다!\n해당 도서를 반납하고 삭제해주세요!".format(self.title, self.isbn), icon='error')
-                return 0
-        except:
+        condition1 = df_rent["BOOK_ISBN"] == self.isbn
+        print(condition1)
+        condition2 = df_rent["RENT_RETURN_DATE"] == -1
+        print(condition2)
+        df_temp = df_rent[condition1 & condition2] 
+        print(df_temp)
+
+        if -1 in list(df_temp["RENT_RETURN_DATE"]):
+            delete_title = df_book["BOOK_TITLE"].loc[self.isbn]
+            messagebox.showinfo("도서 정보 삭제 불가", f"{delete_title}({self.isbn})는(은) 이미 대출 중이라 삭제할 수 없습니다!\n해당 도서를 반납하고 삭제해주세요!", icon='error')
             return 0
         df_book = df_book.drop(self.isbn)
-
         self.isbn = ""
+        df_book.to_csv(DIR_CSV_BOOK, index=False, encoding='CP949')
 
         messagebox.showinfo("도서 정보 삭제 완료", "도서 정보를 삭제하였습니다.")
 
-        df_book.to_csv(DIR_CSV_BOOK, index=False, encoding='CP949')
-# =======
-        # condition1 = df_rent["BOOK_ISBN"] == self.isbn
-        # condition2 = df_rent["RENT_RETURN_DATE"] == -1
-        # df_temp = df_rent[condition1 & condition2] 
-
-        # if -1 in list(df_temp["RENT_RETURN_DATE"]):
-        #     delete_title = df_book["BOOK_TITLE"].loc[self.isbn]
-        #     messagebox.showinfo("도서 정보 삭제 불가", f"{delete_title}({self.isbn})는(은) 이미 대출 중이라 삭제할 수 없습니다!\n해당 도서를 반납하고 삭제해주세요!")
-        #     return 0
-        # df_book = df_book.drop(self.isbn)
-
-        # df_book.to_csv(DIR_CSV_BOOK, index=False, encoding='CP949')
-
-        # messagebox.showinfo("도서 정보 삭제 완료", "도서 정보를 삭제하였습니다.")
-
-# >>>>>>> ff6c8ceb89de1771361370ea98850ceaa7452613
         # entry 내용 삭제
         self.book_editor.entry_isbn.delete("0","end")
         self.book_editor.entry_title.delete("0","end")
@@ -495,6 +480,7 @@ class Panel_Show_Book():
         self.book_editor.entry_price.delete("0","end")
         self.book_editor.entry_link.delete("0","end")
         self.book_editor.entry_book_explain.delete("1.0","end")
+        self.book_editor.label_image.place_forget()
 
     # 멤버 메소드: 도서 정보 [원래대로] 버튼 이벤트
     def event_book_refresh(self):
@@ -507,7 +493,6 @@ class Panel_Show_Book():
         self.book_editor.entry_price.delete("0","end")
         self.book_editor.entry_link.delete("0","end")
         self.book_editor.entry_book_explain.delete("1.0","end")
-
 
         # 도서 정보 출력
         # 아무 검색 하지않고 원래대로 버튼 클릭시 오류 수정
@@ -530,6 +515,13 @@ class Panel_Show_Book():
 
     # 멤버 메소드: 도서 정보 [수정] 버튼 이벤트
     def event_book_save(self):
+        try:
+            if self.isbn == "":
+                messagebox.showinfo("도서 정보 수정 오류", "도서 정보를 먼저 검색해주세요!", icon='error')
+                return 0
+        except:
+            messagebox.showinfo("도서 정보 수정 오류", "도서 정보를 먼저 검색해주세요!", icon='error')
+            return 0
         df_book = pd.read_csv(DIR_CSV_BOOK, encoding='CP949', dtype= {"BOOK_TITLE":object, "BOOK_AUTHOR":object, \
             "BOOK_PUB":object, "BOOK_DESCRIPTION": object, "BOOK_LINK": object})
 

--- a/Window_Add.py
+++ b/Window_Add.py
@@ -103,7 +103,8 @@ class Window_Add_Book():
 
     # 멤버 메소드: [확인] 버튼 이벤트
     def add_book(self):
-        df_book = pd.read_csv(DIR_CSV_BOOK, encoding='CP949')
+        df_book = pd.read_csv(DIR_CSV_BOOK, encoding='CP949', dtype= {"BOOK_TITLE":object, "BOOK_AUTHOR":object, \
+            "BOOK_PUB":object, "BOOK_DESCRIPTION": object, "BOOK_LINK": object})
 
         book_isbn = self.book_editor.get_isbn()
         book_title = self.book_editor.get_title()
@@ -112,6 +113,8 @@ class Window_Add_Book():
         book_price = self.book_editor.get_price()
         book_link = self.book_editor.get_link()
         book_explain = self.book_editor.get_book_explain()
+        book_image = "sample_image/"+book_isbn+".png"
+
         str = messagebox.askquestion("신규 도서 추가", "{}({})을(를) 추가하시겠습니까?".format(book_title, book_isbn))
         if str == "yes":
             if book_isbn.lstrip()=="" or book_title.lstrip()=="" or book_author.lstrip()=="" \
@@ -132,16 +135,23 @@ class Window_Add_Book():
         elif str == 'no':
             return 0
 
-        book_isbn = int(book_isbn)
+        try:
+            self.book_editor.image.save(book_image, "png")
+        except:
+            messagebox.showinfo("이미지 형식 오류", "도서 이미지를 입력해야합니다!", icon='error')
+            return 0
+
         book_price = int(book_price)
 
         new_book = pd.DataFrame.from_dict([{ "BOOK_ISBN": book_isbn, "BOOK_TITLE": book_title, "BOOK_AUTHOR": book_author, 
-        "BOOK_PUB": book_publisher, "BOOK_PRICE": book_price,"BOOK_DESCRIPTION": book_explain, "BOOK_IMAGE": "1", "BOOK_LINK": book_link }])
-
+        "BOOK_PUB": book_publisher, "BOOK_PRICE": book_price,"BOOK_DESCRIPTION": book_explain, "BOOK_IMAGE": book_image, "BOOK_LINK": book_link }])
         df_book = pd.concat([df_book,new_book])
-        df_book.set_index(df_book['BOOK_ISBN'], inplace=True)
+        
         # 도서를 Window_Add에서 추가하지 않고 csv 파일에서 직접 추가하면 불러온 다음, 
         # 추가하는 데이터를 포함한 모든 ISBN이 실수형으로 처리되는 문제 발생
+
         df_book.to_csv(DIR_CSV_BOOK, index=False, encoding='CP949')
         messagebox.showinfo("새 도서 추가 완료", "ISBN {}이 등록되었습니다.".format(book_isbn))
+        self.window.quit()
+        self.window.destroy()
 # ========================================================================================================

--- a/Window_Add.py
+++ b/Window_Add.py
@@ -78,7 +78,7 @@ class Window_Add_User():
 # ========================================================================================================
 
 
-# ================================================================================== ======================
+# ========================================================================================================
 # 클래스: 신규 도서 추가 윈도우
 # ========================================================================================================
 class Window_Add_Book():
@@ -146,7 +146,7 @@ class Window_Add_Book():
         new_book = pd.DataFrame.from_dict([{ "BOOK_ISBN": book_isbn, "BOOK_TITLE": book_title, "BOOK_AUTHOR": book_author, 
         "BOOK_PUB": book_publisher, "BOOK_PRICE": book_price,"BOOK_DESCRIPTION": book_explain, "BOOK_IMAGE": book_image, "BOOK_LINK": book_link }])
         df_book = pd.concat([df_book,new_book])
-        
+
         # 도서를 Window_Add에서 추가하지 않고 csv 파일에서 직접 추가하면 불러온 다음, 
         # 추가하는 데이터를 포함한 모든 ISBN이 실수형으로 처리되는 문제 발생
 


### PR DESCRIPTION
- 신규 도서 추가 커밋으로 인한 밀린 부분 재입력
- 도서 정보 삭제 시 화면에서 이미지도 삭제
- 도서 정보 삭제 후 수정 방지 -> 반드시 검색 후 입력하게 바꿈 (경고 메시지)
- 이미지 확장자 png로 변경 